### PR TITLE
Add support to get prompt template from env

### DIFF
--- a/ChatQnA/chatqna.py
+++ b/ChatQnA/chatqna.py
@@ -19,6 +19,8 @@ from fastapi import Request
 from fastapi.responses import StreamingResponse
 from langchain_core.prompts import PromptTemplate
 
+CHATQNA_PROMPT_TEMPLATE = os.getenv("CHATQNA_PROMPT_TEMPLATE", None)
+
 
 class ChatTemplate:
     @staticmethod
@@ -32,6 +34,8 @@ class ChatTemplate:
 ### 问题：{question}
 ### 回答：
 """
+        elif CHATQNA_PROMPT_TEMPLATE is not None:
+            template = CHATQNA_PROMPT_TEMPLATE
         else:
             template = """
 ### You are a helpful, respectful and honest assistant to help the user with questions. \


### PR DESCRIPTION
## Description

Adds optional loading of prompt template from `CHATQNA_PROMPT_TEMPLATE` env var. This will override the default english prompt.


## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

n/a

## Tests

Tested with a `docker` deployment to Gaudi server running on Intel Developer Cloud
